### PR TITLE
add `exec`, `exec0`, `spawn`, `spawn0` commands

### DIFF
--- a/src/runtime/command/exec/error.rs
+++ b/src/runtime/command/exec/error.rs
@@ -28,6 +28,11 @@ pub enum Panic {
 	InvalidPattern {
 		pattern: OsString,
 		pos: SourcePos,
+	},
+	/// Display string as panic.
+	String {
+		string: &'static str,
+		pos: SourcePos,
 	}
 }
 
@@ -46,6 +51,11 @@ impl Panic {
 	/// Currently, Hush requires patterns to be valid UTF-8.
 	pub fn invalid_pattern(pattern: OsString, pos: SourcePos) -> Self {
 		Self::InvalidPattern { pattern, pos }
+	}
+
+	/// Display string as panic.
+	pub fn string(string: &'static str, pos: SourcePos) -> Self {
+		Self::String { string, pos }
 	}
 }
 
@@ -80,6 +90,8 @@ impl std::fmt::Display for Panic {
 					panic,
 					color::Fg(color::Yellow, pattern)
 				),
+
+            Self::String { string, .. } => f.write_str(string)
 		}
 	}
 }
@@ -96,6 +108,7 @@ impl From<Panic> for crate::runtime::Panic {
 			Panic::InvalidArgs { object, items, pos } => P::invalid_command_args(object, items, pos),
 			Panic::UnsupportedFileDescriptor { fd, pos } => P::unsupported_fd(fd, pos),
 			Panic::InvalidPattern { pattern, pos } => P::invalid_pattern(pattern, pos),
+			Panic::String { string, pos } => P::string(string, pos)
 		}
 	}
 }

--- a/src/runtime/command/exec/error.rs
+++ b/src/runtime/command/exec/error.rs
@@ -91,7 +91,7 @@ impl std::fmt::Display for Panic {
 					color::Fg(color::Yellow, pattern)
 				),
 
-            Self::String { string, .. } => f.write_str(string)
+			Self::String { string, .. } => f.write_str(string)
 		}
 	}
 }

--- a/src/runtime/command/exec/mod.rs
+++ b/src/runtime/command/exec/mod.rs
@@ -285,37 +285,37 @@ impl BasicCommand {
 			}
 		}
 
-        match command_mode {
+		match command_mode {
 			CommandMode::Ready(mut command, is_exec) => {
-		        for (key, value) in self.env.into_vec() { // Use vec's owned iterator.
-			        let value = value.resolve(pos.copy())?;
+				for (key, value) in self.env.into_vec() { // Use vec's owned iterator.
+					let value = value.resolve(pos.copy())?;
 
-			        match value.as_ref() {
-				        [ value ] => command.env(key, value),
-				        other => return Err(
-					        Panic::invalid_args("env variable", other.len() as u32, pos).into()
-				        ),
-			        };
-		        }
-		        Self::spawn(command, stdio, self.redirections, pos, is_exec)
+					match value.as_ref() {
+						[ value ] => command.env(key, value),
+						other => return Err(
+							Panic::invalid_args("env variable", other.len() as u32, pos).into()
+						),
+					};
+				}
+				Self::spawn(command, stdio, self.redirections, pos, is_exec)
 			},
 			CommandMode::ExecNeedProgram => Err(
-			    Panic::string("\x1B[1;33mexec\x1B[22;39m: missing \x1B[1;32mprogram\x1B[22;39m argument ()", pos).into()
+				Panic::string("\x1B[1;33mexec\x1B[22;39m: missing \x1B[1;32mprogram\x1B[22;39m argument ()", pos).into()
 			),
 			CommandMode::Exec0NeedProgram => Err(
-			    Panic::string("\x1B[1;33mexec0\x1B[22;39m: missing \x1B[1;32mprogram\x1B[22;39m and \x1B[1;32marg0\x1B[22;39m arguments", pos).into()
+				Panic::string("\x1B[1;33mexec0\x1B[22;39m: missing \x1B[1;32mprogram\x1B[22;39m and \x1B[1;32marg0\x1B[22;39m arguments", pos).into()
 			),
 			CommandMode::Exec0NeedArg0(_) => Err(
-			    Panic::string("\x1B[1;33mexec0\x1B[22;39m: missing \x1B[1;32marg0\x1B[22;39m argument", pos).into()
+				Panic::string("\x1B[1;33mexec0\x1B[22;39m: missing \x1B[1;32marg0\x1B[22;39m argument", pos).into()
 			),
 			CommandMode::SpawnNeedProgram => Err(
-			    Panic::string("\x1B[1;33mspawn\x1B[22;39m: missing \x1B[1;32mprogram\x1B[22;39m argument", pos).into()
+				Panic::string("\x1B[1;33mspawn\x1B[22;39m: missing \x1B[1;32mprogram\x1B[22;39m argument", pos).into()
 			),
 			CommandMode::Spawn0NeedProgram => Err(
-			    Panic::string("\x1B[1;33mspawn0\x1B[22;39m: missing \x1B[1;32mprogram\x1B[22;39m and \x1B[1;32marg0\x1B[22;39m arguments", pos).into()
+				Panic::string("\x1B[1;33mspawn0\x1B[22;39m: missing \x1B[1;32mprogram\x1B[22;39m and \x1B[1;32marg0\x1B[22;39m arguments", pos).into()
 			),
 			CommandMode::Spawn0NeedArg0(_) => Err(
-			    Panic::string("\x1B[1;33mspawn0\x1B[22;39m: missing \x1B[1;32marg0\x1B[22;39m argument", pos).into()
+				Panic::string("\x1B[1;33mspawn0\x1B[22;39m: missing \x1B[1;32marg0\x1B[22;39m argument", pos).into()
 			)
 		}
 	}

--- a/src/runtime/panic.rs
+++ b/src/runtime/panic.rs
@@ -371,9 +371,8 @@ impl<'a> Display<'a> for Panic {
 					color::Fg(color::Yellow, fmt::Show(value, context))
 				),
 
-		    Self::String { string, pos } => {
+			Self::String { string, pos } =>
 				write!(f, "{} in {}: {}", panic, fmt::Show(pos, context), string)
-			}
 		}
 	}
 }

--- a/src/runtime/panic.rs
+++ b/src/runtime/panic.rs
@@ -93,6 +93,11 @@ pub enum Panic {
 		context: Value,
 		pos: SourcePos,
 	},
+	/// Display string as panic.
+	String {
+		string: &'static str,
+		pos: SourcePos,
+	}
 }
 
 
@@ -218,6 +223,11 @@ impl Panic {
 	/// std.panic
 	pub fn user(context: Value, pos: SourcePos) -> Self {
 		Self::User { context, pos }
+	}
+
+	/// Display string as panic.
+	pub fn string(string: &'static str, pos: SourcePos) -> Self {
+		Self::String { string, pos }
 	}
 }
 
@@ -360,6 +370,10 @@ impl<'a> Display<'a> for Panic {
 					fmt::Show(pos, context),
 					color::Fg(color::Yellow, fmt::Show(value, context))
 				),
+
+		    Self::String { string, pos } => {
+				write!(f, "{} in {}: {}", panic, fmt::Show(pos, context), string)
+			}
 		}
 	}
 }


### PR DESCRIPTION
<table><tr><th>command</th><th>what does command do?</th></tr><tr>
<td>exec program [arg1, arg2, arg3...]</td>
<td>replace hush process with program (arg0 = program)</td>
</tr><tr>
<td>exec0 program arg0 [arg1, arg2, arg3...]</td>
<td>replace hush process with program<br/>similar to <a href="https://man7.org/linux/man-pages/man3/execlp.3.html">execlp(3)</a> C function in unistd.h</td>
</tr><tr>
<td>spawn program [arg1, arg2, arg3...]</td>
<td>spawn program (arg0 = program)<br/><code>{echo asd}</code> is same as <code>{spawn echo asd}</code><br/><code>{cd}</code> is not same as <code>{spawn cd}</code></td>
</tr><tr>
<td>spawn0 program arg0 [arg1, arg2, arg3...]</td>
<td>spawn program</td>
</tr></table>[arg1, arg2, arg3...] means optional arguments<table><tr><th>to do list</th></tr><tr><td><ul>
<li><a href="https://github.com/hush-shell/hush-shell.github.io/pull/7"><del>documentation</del></a></li>
</ul></td></tr></table><em>note: </em>my code might be inefficient